### PR TITLE
Set user agent before retrieving COS endpoints

### DIFF
--- a/src/main/java/com/ibm/cos/endpoints/Endpoints.java
+++ b/src/main/java/com/ibm/cos/endpoints/Endpoints.java
@@ -66,11 +66,6 @@ public class Endpoints {
         return singleSite;
     }
 
-    public static void main(String[] args) throws Exception {
-        Endpoints ep = fetch(args[0]);
-        System.out.println(ep.crossRegion());
-    }
-
     public static Endpoints fetch(String endpointsURL) throws IOException {
         final URL url = new URL(endpointsURL);
         final HttpURLConnection connection = (HttpURLConnection) url.openConnection();

--- a/src/main/java/com/ibm/cos/endpoints/Endpoints.java
+++ b/src/main/java/com/ibm/cos/endpoints/Endpoints.java
@@ -66,16 +66,22 @@ public class Endpoints {
         return singleSite;
     }
 
+    public static void main(String[] args) throws Exception {
+        Endpoints ep = fetch(args[0]);
+        System.out.println(ep.crossRegion());
+    }
+
     public static Endpoints fetch(String endpointsURL) throws IOException {
         final URL url = new URL(endpointsURL);
         final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");
         connection.setInstanceFollowRedirects(true);
+        connection.setRequestProperty("User-Agent", "kafka-connect-ibmcos-sink");
         connection.setReadTimeout(15 * 1000);
 
         final int responseCode = connection.getResponseCode();
         if (responseCode < 200 || responseCode > 299) {
-            throw new IOException("Unable to retrieve endpoint information from: " + endpointsURL);
+            throw new IOException("Unable to retrieve endpoint information from: " + endpointsURL + ", got code: " + responseCode);
         }
 
         final JsonObject root = Json.parse(new InputStreamReader(connection.getInputStream())).asObject();

--- a/src/test/java/com/ibm/cos/endpoints/EndpointsTest.java
+++ b/src/test/java/com/ibm/cos/endpoints/EndpointsTest.java
@@ -16,6 +16,8 @@
 package com.ibm.cos.endpoints;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -55,6 +57,17 @@ public class EndpointsTest {
         assertEquals(3, endpoints.crossRegion().size());
         assertEquals(6, endpoints.regional().size());
         assertEquals(12, endpoints.singleSite().size());
+    }
+
+    @Test
+    public void testFetchPublicEndpoints() throws IOException {
+        String url = "https://control.cloud-object-storage.cloud.ibm.com/v2/endpoints";
+        Endpoints endpoints = Endpoints.fetch(url);
+        assertEquals("iampap.cloud.ibm.com", endpoints.iamPolicy());
+        assertEquals("iam.cloud.ibm.com", endpoints.iamToken());
+        assertFalse(endpoints.crossRegion().isEmpty());
+        assertFalse(endpoints.regional().isEmpty());
+        assertFalse(endpoints.singleSite().isEmpty());
     }
 
     @Test(expected=IOException.class)


### PR DESCRIPTION
This fixes https://github.com/ibm-messaging/kafka-connect-ibmcos-sink/issues/12
