### PR TITLE
change xml.enabled to xml.required

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.1.0'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   id 'java'
   id 'eclipse'
   id 'jacoco'
@@ -76,9 +76,9 @@ test {
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 jacocoTestReport {
-    dependsOn test // tests are required to run before generating the report
+    //dependsOn test // tests are required to run before generating the report
     reports {
-      xml.enabled true
+       xml.required = false
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ test {
 jacocoTestReport {
     //dependsOn test // tests are required to run before generating the report
     reports {
-       xml.required = false
+       xml.required = true
     }
 }
 


### PR DESCRIPTION
The enabled method has been deprecated, running into the below error:

`Could not find method enabled() for arguments [true] on Report xml of type org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport.`

This is required for the kafka-connect sample